### PR TITLE
feat(#171): adding logic to persist login

### DIFF
--- a/lib/component/ListProfiles.dart
+++ b/lib/component/ListProfiles.dart
@@ -45,11 +45,13 @@ Widget buildListProfiles(
             IconButton(
                 icon: const Icon(Icons.settings_outlined),
                 onPressed: () async {
-                  userController.checkToken().then(
-                      (resposta) => MyWidgets().logout(context, resposta));
-                  await profileController.getById(profileId);
-                  Navigator.push(context,
-                      MaterialPageRoute(builder: (context) => UserConfig()));
+                  bool resposta = await userController.checkToken();
+                  if (resposta) {
+                    await profileController.getById(profileId);
+                    Navigator.push(context,
+                        MaterialPageRoute(builder: (context) => UserConfig()));
+                  } else
+                    MyWidgets().logout(context, resposta);
                 })
           ],
         ),

--- a/lib/component/ListProfiles.dart
+++ b/lib/component/ListProfiles.dart
@@ -2,16 +2,21 @@ import 'package:e_vacina/component/MyWidgets.dart';
 import 'package:e_vacina/screens/MainScreen.dart';
 import 'package:e_vacina/screens/UserConfig.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import '../globals.dart';
 
-Widget buildListProfiles(BuildContext context, String name, String prifoleId) {
+final _storage = new FlutterSecureStorage();
+
+Widget buildListProfiles(
+    BuildContext context, int index, String name, String profileId) {
   return GestureDetector(
     onTap: () async {
+      await _storage.write(key: 'profileIndex', value: index.toString());
       userController
           .checkToken()
           .then((resposta) => MyWidgets().logout(context, resposta));
-      await profileController.getById(prifoleId);
+      //await profileController.getById(profileId);
       Navigator.push(
           context, MaterialPageRoute(builder: (context) => MainScreen()));
     },
@@ -41,7 +46,7 @@ Widget buildListProfiles(BuildContext context, String name, String prifoleId) {
                 onPressed: () async {
                   userController.checkToken().then(
                       (resposta) => MyWidgets().logout(context, resposta));
-                  await profileController.getById(prifoleId);
+                  await profileController.getById(profileId);
                   Navigator.push(context,
                       MaterialPageRoute(builder: (context) => UserConfig()));
                 })

--- a/lib/component/ListProfiles.dart
+++ b/lib/component/ListProfiles.dart
@@ -1,3 +1,4 @@
+import 'package:e_vacina/component/MyWidgets.dart';
 import 'package:e_vacina/screens/MainScreen.dart';
 import 'package:e_vacina/screens/UserConfig.dart';
 import 'package:flutter/material.dart';
@@ -7,6 +8,9 @@ import '../globals.dart';
 Widget buildListProfiles(BuildContext context, String name, String prifoleId) {
   return GestureDetector(
     onTap: () async {
+      userController
+          .checkToken()
+          .then((resposta) => MyWidgets().logout(context, resposta));
       await profileController.getById(prifoleId);
       Navigator.push(
           context, MaterialPageRoute(builder: (context) => MainScreen()));
@@ -35,6 +39,8 @@ Widget buildListProfiles(BuildContext context, String name, String prifoleId) {
             IconButton(
                 icon: const Icon(Icons.settings_outlined),
                 onPressed: () async {
+                  userController.checkToken().then(
+                      (resposta) => MyWidgets().logout(context, resposta));
                   await profileController.getById(prifoleId);
                   Navigator.push(context,
                       MaterialPageRoute(builder: (context) => UserConfig()));

--- a/lib/component/ListProfiles.dart
+++ b/lib/component/ListProfiles.dart
@@ -47,6 +47,8 @@ Widget buildListProfiles(
                 onPressed: () async {
                   bool resposta = await userController.checkToken();
                   if (resposta) {
+                    await _storage.write(
+                        key: 'profileIndex', value: index.toString());
                     await profileController.getById(profileId);
                     Navigator.push(context,
                         MaterialPageRoute(builder: (context) => UserConfig()));

--- a/lib/component/ListProfiles.dart
+++ b/lib/component/ListProfiles.dart
@@ -13,12 +13,13 @@ Widget buildListProfiles(
   return GestureDetector(
     onTap: () async {
       await _storage.write(key: 'profileIndex', value: index.toString());
-      userController
-          .checkToken()
-          .then((resposta) => MyWidgets().logout(context, resposta));
-      //await profileController.getById(profileId);
-      Navigator.push(
-          context, MaterialPageRoute(builder: (context) => MainScreen()));
+      bool resposta = await userController.checkToken();
+      if (resposta) {
+        await profileController.getById(profileId);
+        Navigator.push(
+            context, MaterialPageRoute(builder: (context) => MainScreen()));
+      } else
+        MyWidgets().logout(context, resposta);
     },
     child: Container(
       height: 70,

--- a/lib/component/MyWidgets.dart
+++ b/lib/component/MyWidgets.dart
@@ -1,4 +1,7 @@
+import 'package:e_vacina/screens/LoginScreen.dart';
 import 'package:flutter/material.dart';
+
+import '../globals.dart';
 
 class MyWidgets {
   final Color gangGray = Color.fromRGBO(51, 51, 51, 1.0);
@@ -109,13 +112,31 @@ class MyWidgets {
       ),
     );
   }
+
+  void logout(BuildContext context, bool resposta) {
+    if (!resposta) {
+      showDialog(
+        barrierDismissible: false,
+        context: context,
+        builder: (_) => PopUpAlertDialog(
+          "Sua sessão expirou, por favor faça o login novamente.",
+          onPressed: () {
+            userController.logout();
+            Navigator.push(
+                context, MaterialPageRoute(builder: (context) => LoginMenu()));
+          },
+        ),
+      );
+    }
+  }
 }
 
 class PopUpAlertDialog extends StatefulWidget {
   final String label;
   final Function onPressed;
 
-  const PopUpAlertDialog(this.label, {Key key, this.onPressed}) : super(key: key);
+  const PopUpAlertDialog(this.label, {Key key, this.onPressed})
+      : super(key: key);
   @override
   _PopUpAlertDialogState createState() => _PopUpAlertDialogState();
 }

--- a/lib/component/MyWidgets.dart
+++ b/lib/component/MyWidgets.dart
@@ -292,7 +292,6 @@ class _GenderPickerState extends State<GenderPicker> {
             setState(() {
               dropdownValue = newValue;
               widget.controller.text = newValue;
-              print(newValue);
             });
           },
           items: [
@@ -344,7 +343,6 @@ class _DatePickState extends State<DatePick> {
                 widget.errorText == null ? Colors.grey[500] : Colors.red[600],
           )),
           onPressed: () {
-            print(widget.birthDateController.text);
             showDatePicker(
                     context: context,
                     initialDate: _dateTime == null ? DateTime.now() : _dateTime,

--- a/lib/controllers/profileController.dart
+++ b/lib/controllers/profileController.dart
@@ -61,7 +61,6 @@ abstract class ProfileControllerBase with Store {
       changeCurrentCpf(response.data['newProfile']['cpf']);
       changeCurrentBirthDate(response.data['newProfile']['birthDate']);
       changeCurrentSex(response.data['newProfile']['sex']);
-      print(response);
     } catch (err) {
       print("deu exceção crateProfile\n");
       print(err);
@@ -74,9 +73,7 @@ abstract class ProfileControllerBase with Store {
   delete(String profileId) async {
     bool resposta = true;
     try {
-      Response response = await api.deleteProfile(profileId);
-      print(response);
-      print(response.statusCode);
+      await api.deleteProfile(profileId);
     } catch (err) {
       print("deu exceção\n");
       resposta = false;
@@ -88,10 +85,7 @@ abstract class ProfileControllerBase with Store {
   update(String name, String cpf, String sex, String birthDate) async {
     bool profile = true;
     try {
-      Response response =
-          await api.updateProfile(currentId, name, cpf, sex, birthDate);
-      print(response);
-      print(response.statusCode);
+      await api.updateProfile(currentId, name, cpf, sex, birthDate);
     } catch (err) {
       print("deu exceção\n");
       print(err);

--- a/lib/controllers/profileController.dart
+++ b/lib/controllers/profileController.dart
@@ -1,13 +1,10 @@
 import 'package:mobx/mobx.dart';
 import 'package:dio/dio.dart';
 import 'package:e_vacina/globals.dart';
-// import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 part 'profileController.g.dart';
 
 class ProfileController = ProfileControllerBase with _$ProfileController;
-
-//final _storage = new FlutterSecureStorage();
 
 abstract class ProfileControllerBase with Store {
   @observable
@@ -45,6 +42,12 @@ abstract class ProfileControllerBase with Store {
 
   @action
   changeCurrentNames(List value) => names = value;
+
+  @observable
+  int currentIndex = 0;
+
+  @action
+  changeCurrentIndex(int value) => currentIndex = value;
 
   @action
   createProfile(String userId, String name, String cpf, String sex,

--- a/lib/controllers/userController.dart
+++ b/lib/controllers/userController.dart
@@ -107,22 +107,19 @@ abstract class UserControllerBase with Store {
     String resposta = "true";
     changeRegister(true);
     try {
-      Response response = await api.registerUser(email, phoneNumber, password);
+      await api.registerUser(email, phoneNumber, password);
       await login(email, password);
-      print(response.statusCode);
     } catch (err) {
       return err.response.data.toString();
     }
     bool rProfile = await profileController.createProfile(
         userId, name, cpf, sex, birthDate);
     if (!rProfile) resposta = "false";
-    print("resposta profile");
     changeEmail(email);
     changePassword(password);
     changePhoneNumber(phoneNumber);
     if (resposta == "false") {
       try {
-        print("userId: $userId, email: $email");
         await delete();
       } catch (e2) {
         print("erro delete: $e2");
@@ -135,9 +132,7 @@ abstract class UserControllerBase with Store {
 
   @action
   delete() async {
-    Response response = await api.deleteUser(userId, token);
-    print(response);
-    print(response.statusCode);
+    await api.deleteUser(userId, token);
   }
 
   @action
@@ -146,8 +141,6 @@ abstract class UserControllerBase with Store {
         await api.updateUser(email, phoneNumber, password, userId, token);
     changeEmail(response.data['updtedUser']['email']);
     changePhoneNumber(response.data['updtedUser']['phoneNumber']);
-    print(response);
-    print(response.statusCode);
   }
 
   @action
@@ -164,7 +157,6 @@ abstract class UserControllerBase with Store {
     if (hasExpired) {
       if (!await persistLogin()) _resposta = false;
     }
-    print("Resposta hasExpired $hasExpired");
     return _resposta;
   }
 }

--- a/lib/controllers/userController.dart
+++ b/lib/controllers/userController.dart
@@ -1,29 +1,29 @@
 import 'package:mobx/mobx.dart';
 import 'package:dio/dio.dart';
 import 'package:e_vacina/globals.dart';
-// import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 part 'userController.g.dart';
 
 class UserController = UserControllerBase with _$UserController;
 
-// final _storage = new FlutterSecureStorage();
+final _storage = new FlutterSecureStorage();
 
 abstract class UserControllerBase with Store {
   @observable
-  String email='';
+  String email = '';
 
   @action
   changeEmail(String value) => email = value;
 
   @observable
-  String phoneNumber= '';
+  String phoneNumber = '';
 
   @action
   changePhoneNumber(String value) => phoneNumber = value;
 
   @observable
-  String password= '';
+  String password = '';
 
   @action
   changePassword(String value) => password = value;
@@ -35,7 +35,7 @@ abstract class UserControllerBase with Store {
   changeUserId(String value) => userId = value;
 
   @observable
-  dynamic token='';
+  dynamic token = '';
 
   @action
   changeToken(String value) => token = value;
@@ -64,9 +64,10 @@ abstract class UserControllerBase with Store {
       await getProfiles(userId);
       if (!isRegister)
         await profileController.changeCurrentId(profiles[0]['_id']);
-      // await _storage.write(key: 'token', value: token);
-      // await _storage.write(key: 'userId', value: userId);
-      print('$token');
+      await _storage.write(key: 'email', value: email);
+      await _storage.write(key: 'password', value: password);
+      await _storage.write(key: 'token', value: token);
+      await _storage.write(key: 'userId', value: userId);
     } on DioError catch (err) {
       print("Erro: ${err.response.statusCode}");
       resposta = false;
@@ -75,10 +76,26 @@ abstract class UserControllerBase with Store {
   }
 
   @action
+  persistLogin() async {
+    bool _resposta = true;
+    try {
+      String _password = await _storage.read(key: 'password');
+      await _storage.read(key: 'token');
+      String _email = await _storage.read(key: 'email');
+      print(_password);
+      bool teste = await login(_email, _password);
+      if (!teste) _resposta = false;
+    } catch (err) {
+      _resposta = false;
+    }
+    return _resposta;
+  }
+
+  @action
   logout() async {
     changeToken('');
     changeUserId('');
-    // await _storage.deleteAll();
+    await _storage.deleteAll();
   }
 
   @action

--- a/lib/controllers/userController.dart
+++ b/lib/controllers/userController.dart
@@ -63,13 +63,14 @@ abstract class UserControllerBase with Store {
       changeEmail(response.data['user']['email']);
       changePhoneNumber(response.data['user']['phoneNumber']);
       await getProfiles(userId);
-      if (!isRegister)
+      if (!isRegister) {
         await profileController
             .changeCurrentId(profiles[profileController.currentIndex]['_id']);
-      await _storage.write(key: 'email', value: email);
-      await _storage.write(key: 'password', value: password);
-      await _storage.write(key: 'token', value: token);
-      await _storage.write(key: 'userId', value: userId);
+        await _storage.write(key: 'email', value: email);
+        await _storage.write(key: 'password', value: password);
+        await _storage.write(key: 'token', value: token);
+        await _storage.write(key: 'userId', value: userId);
+      }
     } on DioError catch (err) {
       print("Erro: ${err.response.statusCode}");
       resposta = false;
@@ -98,6 +99,7 @@ abstract class UserControllerBase with Store {
   logout() async {
     changeToken('');
     changeUserId('');
+    await _storage.write(key: 'profileIndex', value: "0");
     await _storage.deleteAll();
   }
 

--- a/lib/controllers/userController.dart
+++ b/lib/controllers/userController.dart
@@ -64,7 +64,8 @@ abstract class UserControllerBase with Store {
       changePhoneNumber(response.data['user']['phoneNumber']);
       await getProfiles(userId);
       if (!isRegister)
-        await profileController.changeCurrentId(profiles[0]['_id']);
+        await profileController
+            .changeCurrentId(profiles[profileController.currentIndex]['_id']);
       await _storage.write(key: 'email', value: email);
       await _storage.write(key: 'password', value: password);
       await _storage.write(key: 'token', value: token);
@@ -82,6 +83,9 @@ abstract class UserControllerBase with Store {
     try {
       String _password = await _storage.read(key: 'password');
       String _email = await _storage.read(key: 'email');
+      String _index = await _storage.read(key: 'profileIndex') ?? "0";
+      int intParse = int.parse(_index);
+      profileController.changeCurrentIndex(intParse);
       bool rLogin = await login(_email, _password);
       if (!rLogin) _resposta = false;
     } catch (err) {

--- a/lib/controllers/userController.dart
+++ b/lib/controllers/userController.dart
@@ -1,3 +1,4 @@
+import 'package:jwt_decoder/jwt_decoder.dart';
 import 'package:mobx/mobx.dart';
 import 'package:dio/dio.dart';
 import 'package:e_vacina/globals.dart';
@@ -150,5 +151,16 @@ abstract class UserControllerBase with Store {
     Response response = await api.getProfilesByUserId(userId);
     await changeProfiles(response.data['user']['profilesIds']);
     return response.data['user']['profilesIds'];
+  }
+
+  @action
+  checkToken() async {
+    bool _resposta = true;
+    bool hasExpired = JwtDecoder.isExpired(token);
+    if (hasExpired) {
+      if (!await persistLogin()) _resposta = false;
+    }
+    print("Resposta hasExpired $hasExpired");
+    return _resposta;
   }
 }

--- a/lib/controllers/userController.dart
+++ b/lib/controllers/userController.dart
@@ -80,11 +80,9 @@ abstract class UserControllerBase with Store {
     bool _resposta = true;
     try {
       String _password = await _storage.read(key: 'password');
-      await _storage.read(key: 'token');
       String _email = await _storage.read(key: 'email');
-      print(_password);
-      bool teste = await login(_email, _password);
-      if (!teste) _resposta = false;
+      bool rLogin = await login(_email, _password);
+      if (!rLogin) _resposta = false;
     } catch (err) {
       _resposta = false;
     }

--- a/lib/controllers/vaccineController.dart
+++ b/lib/controllers/vaccineController.dart
@@ -61,7 +61,6 @@ abstract class VaccineControllerBase with Store {
   @action
   getTakenVaccine() async {
     Response response = await api.getTakenVaccines();
-    print(response.data["takenVaccine"]);
     await changeTakenVaccine(response.data["takenVaccine"]);
     return response.data["takenVaccine"];
   }

--- a/lib/globals.dart
+++ b/lib/globals.dart
@@ -10,7 +10,7 @@ VaccineController vaccineController = new VaccineController();
 Api api = new Api();
 
 var options = BaseOptions(
-  baseUrl: 'http://localhost:3000',
+  baseUrl: 'localhost:3000', //'https://6f7f2a7a5e77.ngrok.io',
   connectTimeout: 5000,
   receiveTimeout: 3000,
 );

--- a/lib/screens/AddVacinaScreen.dart
+++ b/lib/screens/AddVacinaScreen.dart
@@ -58,7 +58,6 @@ class _AddVacinaState extends State<AddVacina> {
                   vaccineController
                       .postTakenVaccine()
                       .then((resposta) => validate(resposta));
-                  print("cadastou");
                 })),
             Container(
               height: MediaQuery.of(context).size.height * 0.1,

--- a/lib/screens/CreateProfileScreen.dart
+++ b/lib/screens/CreateProfileScreen.dart
@@ -25,6 +25,19 @@ class _CreateProfileState extends State<CreateProfile> {
   String _wrongSex;
   bool _error = false;
 
+  void changeScreen(bool resposta) {
+    if (resposta) {
+      if (isEmpty() == false) {
+        _error = false;
+        profileController
+            .createProfile(userController.userId, _name, _cpf, _sex, _birthDate)
+            .then((resposta) => validate(resposta));
+      } else
+        _error = true;
+    } else
+      MyWidgets().logout(context, resposta);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -65,16 +78,9 @@ class _CreateProfileState extends State<CreateProfile> {
                       sexCon.text == '1'
                           ? _sex = 'Masculino'
                           : _sex = 'Feminino';
-                      userController.checkToken().then(
-                          (resposta) => MyWidgets().logout(context, resposta));
-                      if (isEmpty() == false) {
-                        _error = false;
-                        profileController
-                            .createProfile(userController.userId, _name, _cpf,
-                                _sex, _birthDate)
-                            .then((resposta) => validate(resposta));
-                      } else
-                        _error = true;
+                      userController
+                          .checkToken()
+                          .then((resposta) => changeScreen(resposta));
                     });
                   },
                   child: Text(

--- a/lib/screens/CreateProfileScreen.dart
+++ b/lib/screens/CreateProfileScreen.dart
@@ -76,9 +76,6 @@ class _CreateProfileState extends State<CreateProfile> {
                       } else
                         _error = true;
                     });
-
-                    print('Sexo:$_sex');
-                    print('Data: $_birthDate');
                   },
                   child: Text(
                     "Salvar",

--- a/lib/screens/CreateProfileScreen.dart
+++ b/lib/screens/CreateProfileScreen.dart
@@ -65,6 +65,8 @@ class _CreateProfileState extends State<CreateProfile> {
                       sexCon.text == '1'
                           ? _sex = 'Masculino'
                           : _sex = 'Feminino';
+                      userController.checkToken().then(
+                          (resposta) => MyWidgets().logout(context, resposta));
                       if (isEmpty() == false) {
                         _error = false;
                         profileController

--- a/lib/screens/LoginScreen.dart
+++ b/lib/screens/LoginScreen.dart
@@ -24,8 +24,7 @@ class _LoginMenuState extends State<LoginMenu> {
   void mudaTela(bool resposta) async {
     if (resposta == true) {
       profiles = userController.profiles;
-      await profileController
-          .getById(profiles[profileController.currentIndex]["_id"]);
+      await profileController.getById(profiles[0]["_id"]);
       Navigator.push(
           context, MaterialPageRoute(builder: (context) => MainScreen()));
     } else {

--- a/lib/screens/LoginScreen.dart
+++ b/lib/screens/LoginScreen.dart
@@ -35,6 +35,16 @@ class _LoginMenuState extends State<LoginMenu> {
     }
   }
 
+  /*bool _isValid = false;
+  void chooseScreen(bool token) {
+    if (token == true) {
+      setState(() {
+        _isValid = true;
+      });
+    }
+    print(token);
+  }*/
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/lib/screens/LoginScreen.dart
+++ b/lib/screens/LoginScreen.dart
@@ -36,16 +36,6 @@ class _LoginMenuState extends State<LoginMenu> {
     }
   }
 
-  /*bool _isValid = false;
-  void chooseScreen(bool token) {
-    if (token == true) {
-      setState(() {
-        _isValid = true;
-      });
-    }
-    print(token);
-  }*/
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -88,7 +78,6 @@ class _LoginMenuState extends State<LoginMenu> {
             }),
             Text('OU\n'),
             MyWidgets().button('Registre-se', 200.0, 50.0, 16, gangGray, () {
-              print('Registrar');
               Navigator.push(context,
                   MaterialPageRoute(builder: (context) => RegisterScreen()));
             }),

--- a/lib/screens/LoginScreen.dart
+++ b/lib/screens/LoginScreen.dart
@@ -24,7 +24,8 @@ class _LoginMenuState extends State<LoginMenu> {
   void mudaTela(bool resposta) async {
     if (resposta == true) {
       profiles = userController.profiles;
-      await profileController.getById(profiles[0]["_id"]);
+      await profileController
+          .getById(profiles[profileController.currentIndex]["_id"]);
       Navigator.push(
           context, MaterialPageRoute(builder: (context) => MainScreen()));
     } else {

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -111,6 +111,22 @@ class _MainScreenState extends State<MainScreen> {
 }
 
 class ConfigTab extends StatelessWidget {
+  void infoLogin(BuildContext context, bool resposta) {
+    if (resposta) {
+      Navigator.push(
+          context, MaterialPageRoute(builder: (context) => AdminConfig()));
+    } else
+      MyWidgets().logout(context, resposta);
+  }
+
+  void profiles(BuildContext context, bool resposta) {
+    if (resposta) {
+      Navigator.push(
+          context, MaterialPageRoute(builder: (context) => ProfileScreen()));
+    } else
+      MyWidgets().logout(context, resposta);
+  }
+
   @override
   Widget build(BuildContext context) {
     return SingleChildScrollView(
@@ -136,9 +152,7 @@ class ConfigTab extends StatelessWidget {
               () {
             userController
                 .checkToken()
-                .then((resposta) => MyWidgets().logout(context, resposta));
-            Navigator.push(context,
-                MaterialPageRoute(builder: (context) => AdminConfig()));
+                .then((resposta) => infoLogin(context, resposta));
           }),
           MyWidgets().borderButton(
               'Geral', 86, 25, Colors.black, Icons.arrow_forward, () {
@@ -149,9 +163,7 @@ class ConfigTab extends StatelessWidget {
               'Perfis', 86, 25, Colors.black, Icons.arrow_forward, () {
             userController
                 .checkToken()
-                .then((resposta) => MyWidgets().logout(context, resposta));
-            Navigator.push(context,
-                MaterialPageRoute(builder: (context) => ProfileScreen()));
+                .then((resposta) => profiles(context, resposta));
           }),
           MyWidgets().borderButton(
               'Termos de Uso', 86, 25, Colors.black, Icons.arrow_forward, () {

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -144,6 +144,9 @@ class ConfigTab extends StatelessWidget {
           }),
           MyWidgets().borderButton(
               'Perfis', 86, 25, Colors.black, Icons.arrow_forward, () {
+            userController
+                .checkToken()
+                .then((resposta) => MyWidgets().logout(context, resposta));
             Navigator.push(context,
                 MaterialPageRoute(builder: (context) => ProfileScreen()));
           }),

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -226,7 +226,7 @@ class SearchTab extends StatefulWidget {
 class _SearchTabState extends State<SearchTab> {
   String search = '';
   int i = 0;
-  List items;
+  List items = [];
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -134,6 +134,9 @@ class ConfigTab extends StatelessWidget {
           MyWidgets().borderButton(
               'Informações de Login', 86, 25, Colors.black, Icons.arrow_forward,
               () {
+            userController
+                .checkToken()
+                .then((resposta) => MyWidgets().logout(context, resposta));
             Navigator.push(context,
                 MaterialPageRoute(builder: (context) => AdminConfig()));
           }),

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -245,7 +245,6 @@ class _SearchTabState extends State<SearchTab> {
                 child: FutureBuilder(
                     future: vaccineController.getVaccines(),
                     builder: (context, projectSnap) {
-                      // print(projectSnap);
                       if (projectSnap.hasError) {
                         return Text("Something went wrong");
                       } else if (projectSnap.connectionState ==

--- a/lib/screens/ProfilesScreen.dart
+++ b/lib/screens/ProfilesScreen.dart
@@ -61,7 +61,6 @@ class _ProfileScreenState extends State<ProfileScreen> {
             child: IconButton(
               icon: const Icon(Icons.arrow_back),
               onPressed: () {
-                print('voltar');
                 Navigator.push(context,
                     MaterialPageRoute(builder: (context) => MainScreen()));
               },
@@ -106,10 +105,8 @@ class _ProfileScreenState extends State<ProfileScreen> {
             FutureBuilder(
                 future: userController.getProfiles(userController.userId),
                 builder: (context, projectSnaps) {
-                  print("PROJETO ${projectSnaps.data}");
                   if (projectSnaps.hasData) {
                     _isLoading = false;
-                    print(_isLoading);
                   }
                   if (_isLoading == true) {
                     return Container(

--- a/lib/screens/ProfilesScreen.dart
+++ b/lib/screens/ProfilesScreen.dart
@@ -13,13 +13,13 @@ class _ProfileScreenState extends State<ProfileScreen> {
   List array = profileController.currentName.split(' ');
   String _nome = profileController.currentName;
   bool _isLoading = true;
-  
 
-  String splitName(List array){
+  String splitName(List array) {
     String name;
-    if (array.length > 1){
-      name = array[0].substring(0, 1).toUpperCase() + array[1].substring(0,1).toUpperCase();
-    }else{
+    if (array.length > 1) {
+      name = array[0].substring(0, 1).toUpperCase() +
+          array[1].substring(0, 1).toUpperCase();
+    } else {
       name = array[0].substring(0, 1).toUpperCase();
     }
     return name;

--- a/lib/screens/ProfilesScreen.dart
+++ b/lib/screens/ProfilesScreen.dart
@@ -26,6 +26,14 @@ class _ProfileScreenState extends State<ProfileScreen> {
     return name;
   }
 
+  void createProfile(bool resposta) {
+    if (resposta) {
+      Navigator.push(
+          context, MaterialPageRoute(builder: (context) => CreateProfile()));
+    } else
+      MyWidgets().logout(context, resposta);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -95,10 +103,9 @@ class _ProfileScreenState extends State<ProfileScreen> {
                   ],
                 ),
                 onTap: () {
-                  userController.checkToken().then(
-                      (resposta) => MyWidgets().logout(context, resposta));
-                  Navigator.push(context,
-                      MaterialPageRoute(builder: (context) => CreateProfile()));
+                  userController
+                      .checkToken()
+                      .then((resposta) => createProfile(resposta));
                 },
               ),
             ),

--- a/lib/screens/ProfilesScreen.dart
+++ b/lib/screens/ProfilesScreen.dart
@@ -1,4 +1,5 @@
 import 'package:e_vacina/component/ListProfiles.dart';
+import 'package:e_vacina/component/MyWidgets.dart';
 import 'package:e_vacina/screens/CreateProfileScreen.dart';
 import 'package:flutter/material.dart';
 import 'MainScreen.dart';
@@ -95,6 +96,8 @@ class _ProfileScreenState extends State<ProfileScreen> {
                   ],
                 ),
                 onTap: () {
+                  userController.checkToken().then(
+                      (resposta) => MyWidgets().logout(context, resposta));
                   Navigator.push(context,
                       MaterialPageRoute(builder: (context) => CreateProfile()));
                 },

--- a/lib/screens/ProfilesScreen.dart
+++ b/lib/screens/ProfilesScreen.dart
@@ -130,7 +130,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                       itemBuilder: (context, i) {
                         List profile = projectSnaps.data;
                         return buildListProfiles(
-                            context, profile[i]['name'], profile[i]['_id']);
+                            context, i, profile[i]['name'], profile[i]['_id']);
                       });
                 })
           ],

--- a/lib/screens/SplashScreen.dart
+++ b/lib/screens/SplashScreen.dart
@@ -1,3 +1,5 @@
+import 'package:e_vacina/globals.dart';
+import 'package:e_vacina/screens/MainScreen.dart';
 import 'package:splashscreen/splashscreen.dart';
 import 'package:e_vacina/screens/LoginScreen.dart';
 import 'package:flutter/material.dart';
@@ -9,19 +11,54 @@ class InitialSplashScreen extends StatefulWidget {
 }
 
 class _SplashScreenState extends State<InitialSplashScreen> {
+  Future<Widget> loadFromFuture() async {
+    bool resposta = false;
+    resposta = await userController.persistLogin();
+    if (resposta)
+      return Future.value(MainScreen());
+    else
+      return Future.value(LoginMenu());
+  }
+
   @override
   Widget build(BuildContext context) {
-    return _introScreen(context);
+    return Stack(
+      children: <Widget>[
+        SplashScreen(
+          seconds: 2,
+          backgroundColor: Colors.white,
+          navigateAfterSeconds: LoginMenu(),
+          loaderColor: Theme.of(context).primaryColor,
+          title: Text(
+            'e-Vacina',
+            style: TextStyle(
+              fontSize: 64,
+              fontFamily: 'SuezOne',
+              color: Theme.of(context).primaryColor,
+            ),
+          ),
+        ),
+      ],
+    );
   }
 }
 
-Widget _introScreen(context) {
+/*Widget _introScreen(context) {
+  bool _isValid = false;
+  void chooseScreen(bool resposta) {
+    if (resposta) {
+      _isValid = true;
+    }
+    print("chooseScreen: $_isValid");
+  }
+
+  userController.persistLogin().then((resposta) => chooseScreen(resposta));
   return Stack(
     children: <Widget>[
       SplashScreen(
-        seconds: 1,
+        seconds: 4,
         backgroundColor: Colors.white,
-        navigateAfterSeconds: LoginMenu(),
+        navigateAfterSeconds: ,
         loaderColor: Theme.of(context).primaryColor,
         title: Text(
           'e-Vacina',
@@ -35,3 +72,8 @@ Widget _introScreen(context) {
     ],
   );
 }
+
+changeScreen(bool isValid) {
+  if (isValid) return HelpScreen();
+  return LoginMenu();
+}*/

--- a/lib/screens/SplashScreen.dart
+++ b/lib/screens/SplashScreen.dart
@@ -13,30 +13,22 @@ class InitialSplashScreen extends StatefulWidget {
 class _SplashScreenState extends State<InitialSplashScreen> {
   bool isValid = false;
 
-  void loadFromFuture() async {
+  Future<Widget> loadFromFuture() async {
     bool resposta = await userController.persistLogin();
     if (resposta) {
       List profiles = userController.profiles;
       await profileController
           .getById(profiles[profileController.currentIndex]["_id"]);
+      return Future.value(new MainScreen());
     }
-    setState(() {
-      isValid = resposta;
-    });
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    loadFromFuture();
+    return Future.value(new LoginMenu());
   }
 
   @override
   Widget build(BuildContext context) {
     return SplashScreen(
-      seconds: 10,
       backgroundColor: Colors.white,
-      navigateAfterSeconds: isValid ? MainScreen() : LoginMenu(),
+      navigateAfterFuture: loadFromFuture(),
       loaderColor: Theme.of(context).primaryColor,
       title: Text(
         'e-Vacina',

--- a/lib/screens/SplashScreen.dart
+++ b/lib/screens/SplashScreen.dart
@@ -17,7 +17,8 @@ class _SplashScreenState extends State<InitialSplashScreen> {
     bool resposta = await userController.persistLogin();
     if (resposta) {
       List profiles = userController.profiles;
-      await profileController.getById(profiles[0]["_id"]);
+      await profileController
+          .getById(profiles[profileController.currentIndex]["_id"]);
     }
     setState(() {
       isValid = resposta;
@@ -34,7 +35,7 @@ class _SplashScreenState extends State<InitialSplashScreen> {
   Widget build(BuildContext context) {
     print("isValid init: $isValid");
     return SplashScreen(
-      seconds: 5,
+      seconds: 10,
       backgroundColor: Colors.white,
       navigateAfterSeconds: isValid ? MainScreen() : LoginMenu(),
       loaderColor: Theme.of(context).primaryColor,

--- a/lib/screens/SplashScreen.dart
+++ b/lib/screens/SplashScreen.dart
@@ -7,10 +7,10 @@ import 'package:flutter/cupertino.dart';
 
 class InitialSplashScreen extends StatefulWidget {
   @override
-  InitialSplashScreenState createState() => InitialSplashScreenState();
+  _SplashScreenState createState() => _SplashScreenState();
 }
 
-class InitialSplashScreenState extends State<InitialSplashScreen> {
+class _SplashScreenState extends State<InitialSplashScreen> {
   bool isValid = false;
 
   void loadFromFuture() async {
@@ -28,14 +28,13 @@ class InitialSplashScreenState extends State<InitialSplashScreen> {
   void initState() {
     super.initState();
     loadFromFuture();
-    print("isValid: $isValid");
   }
 
   @override
   Widget build(BuildContext context) {
     print("isValid init: $isValid");
     return SplashScreen(
-      seconds: 3,
+      seconds: 5,
       backgroundColor: Colors.white,
       navigateAfterSeconds: isValid ? MainScreen() : LoginMenu(),
       loaderColor: Theme.of(context).primaryColor,
@@ -50,38 +49,3 @@ class InitialSplashScreenState extends State<InitialSplashScreen> {
     );
   }
 }
-
-/*Widget _introScreen(context) {
-  bool _isValid = false;
-  void chooseScreen(bool resposta) {
-    if (resposta) {
-      _isValid = true;
-    }
-    print("chooseScreen: $_isValid");
-  }
-
-  userController.persistLogin().then((resposta) => chooseScreen(resposta));
-  return Stack(
-    children: <Widget>[
-      SplashScreen(
-        seconds: 4,
-        backgroundColor: Colors.white,
-        navigateAfterSeconds: ,
-        loaderColor: Theme.of(context).primaryColor,
-        title: Text(
-          'e-Vacina',
-          style: TextStyle(
-            fontSize: 64,
-            fontFamily: 'SuezOne',
-            color: Theme.of(context).primaryColor,
-          ),
-        ),
-      ),
-    ],
-  );
-}
-
-changeScreen(bool isValid) {
-  if (isValid) return HelpScreen();
-  return LoginMenu();
-}*/

--- a/lib/screens/SplashScreen.dart
+++ b/lib/screens/SplashScreen.dart
@@ -33,7 +33,6 @@ class _SplashScreenState extends State<InitialSplashScreen> {
 
   @override
   Widget build(BuildContext context) {
-    print("isValid init: $isValid");
     return SplashScreen(
       seconds: 10,
       backgroundColor: Colors.white,

--- a/lib/screens/SplashScreen.dart
+++ b/lib/screens/SplashScreen.dart
@@ -7,38 +7,46 @@ import 'package:flutter/cupertino.dart';
 
 class InitialSplashScreen extends StatefulWidget {
   @override
-  _SplashScreenState createState() => _SplashScreenState();
+  InitialSplashScreenState createState() => InitialSplashScreenState();
 }
 
-class _SplashScreenState extends State<InitialSplashScreen> {
-  Future<Widget> loadFromFuture() async {
-    bool resposta = false;
-    resposta = await userController.persistLogin();
-    if (resposta)
-      return Future.value(MainScreen());
-    else
-      return Future.value(LoginMenu());
+class InitialSplashScreenState extends State<InitialSplashScreen> {
+  bool isValid = false;
+
+  void loadFromFuture() async {
+    bool resposta = await userController.persistLogin();
+    if (resposta) {
+      List profiles = userController.profiles;
+      await profileController.getById(profiles[0]["_id"]);
+    }
+    setState(() {
+      isValid = resposta;
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    loadFromFuture();
+    print("isValid: $isValid");
   }
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      children: <Widget>[
-        SplashScreen(
-          seconds: 2,
-          backgroundColor: Colors.white,
-          navigateAfterSeconds: LoginMenu(),
-          loaderColor: Theme.of(context).primaryColor,
-          title: Text(
-            'e-Vacina',
-            style: TextStyle(
-              fontSize: 64,
-              fontFamily: 'SuezOne',
-              color: Theme.of(context).primaryColor,
-            ),
-          ),
+    print("isValid init: $isValid");
+    return SplashScreen(
+      seconds: 3,
+      backgroundColor: Colors.white,
+      navigateAfterSeconds: isValid ? MainScreen() : LoginMenu(),
+      loaderColor: Theme.of(context).primaryColor,
+      title: Text(
+        'e-Vacina',
+        style: TextStyle(
+          fontSize: 64,
+          fontFamily: 'SuezOne',
+          color: Theme.of(context).primaryColor,
         ),
-      ],
+      ),
     );
   }
 }

--- a/lib/screens/UserConfig.dart
+++ b/lib/screens/UserConfig.dart
@@ -91,7 +91,8 @@ class _UserConfigState extends State<UserConfig> {
               padding: const EdgeInsets.only(left: 30.0),
               child: IconButton(
                 icon: const Icon(Icons.arrow_back),
-                onPressed: () {
+                onPressed: () async {
+                  await profileController.getById(profileController.currentId);
                   Navigator.pop(context);
                 },
                 alignment: Alignment.centerRight,
@@ -203,9 +204,9 @@ class _UserConfigState extends State<UserConfig> {
           builder: (_) => PopUpAlertDialog(
                 "Perfil atualizado com sucesso.",
                 onPressed: () async {
+                  await profileController.getById(profileController.currentId);
                   Navigator.push(context,
                       MaterialPageRoute(builder: (context) => MainScreen()));
-                  await profileController.getById(profileController.currentId);
                 },
               ));
     }

--- a/lib/screens/UserConfig.dart
+++ b/lib/screens/UserConfig.dart
@@ -230,10 +230,10 @@ class _UserConfigState extends State<UserConfig> {
           "Perfil deletado com sucesso.",
           onPressed: () async {
             await _storage.write(key: 'profileIndex', value: "0");
+            await userController.getProfiles(userController.userId);
             await profileController.getById(userController.profiles[0]['_id']);
             Navigator.push(
                 context, MaterialPageRoute(builder: (context) => MainScreen()));
-            await userController.getProfiles(userController.userId);
           },
         ),
       );

--- a/lib/screens/UserConfig.dart
+++ b/lib/screens/UserConfig.dart
@@ -37,7 +37,6 @@ class _UserConfigState extends State<UserConfig> {
     profileController.currentSex == 'Masculino'
         ? sexCon.text = '1'
         : sexCon.text = '2';
-    print(birthDateCon.text);
   }
 
   @override
@@ -147,7 +146,6 @@ class _UserConfigState extends State<UserConfig> {
                     .checkToken()
                     .then((resposta) => MyWidgets().logout(context, resposta));
                 setState(() {
-                  print(userController.profiles.length);
                   if (userController.profiles.length == 1) {
                     validateDelete(false);
                   } else {

--- a/lib/screens/UserConfig.dart
+++ b/lib/screens/UserConfig.dart
@@ -79,6 +79,8 @@ class _UserConfigState extends State<UserConfig> {
                       sexCon.text == '1'
                           ? _sex = 'Masculino'
                           : _sex = 'Feminino';
+                      userController.checkToken().then(
+                          (resposta) => MyWidgets().logout(context, resposta));
                       if (isEmpty() == false) {
                         _error = false;
                         profileController
@@ -141,6 +143,9 @@ class _UserConfigState extends State<UserConfig> {
               MyWidgets().button(
                   'Excluir Usuário', 150, 45, 17, Color.fromRGBO(255, 0, 0, 1),
                   () {
+                userController
+                    .checkToken()
+                    .then((resposta) => MyWidgets().logout(context, resposta));
                 setState(() {
                   print(userController.profiles.length);
                   if (userController.profiles.length == 1) {
@@ -197,8 +202,8 @@ class _UserConfigState extends State<UserConfig> {
       showDialog(
         barrierDismissible: false,
         context: context,
-        builder: (_) =>
-            PopUpAlertDialog("Impossivel excluir todos os perfis", onPressed: () {
+        builder: (_) => PopUpAlertDialog("Impossivel excluir todos os perfis",
+            onPressed: () {
           Navigator.of(context).pop();
         }),
       );

--- a/lib/screens/adminConfig_screen.dart
+++ b/lib/screens/adminConfig_screen.dart
@@ -49,7 +49,6 @@ class AdminConfigState extends State<AdminConfig> {
             child: IconButton(
               icon: const Icon(Icons.arrow_back),
               onPressed: () {
-                print('voltar');
                 Navigator.pop(context);
               },
               alignment: Alignment.centerRight,
@@ -71,8 +70,6 @@ class AdminConfigState extends State<AdminConfig> {
                   userController.delete();
                   Navigator.push(context,
                       MaterialPageRoute(builder: (context) => LoginMenu()));
-                  print(
-                      "Excluir Conta Email:$_email, Telefone:$_phone, Password: $_password");
                 },
                 child: Text(
                   "Excluir\nUsuário",

--- a/lib/screens/adminConfig_screen.dart
+++ b/lib/screens/adminConfig_screen.dart
@@ -108,6 +108,8 @@ class AdminConfigState extends State<AdminConfig> {
                     _phone = phoneCon.text;
                     _password = passwordCon.text;
                   });
+                  userController.checkToken().then(
+                      (resposta) => MyWidgets().logout(context, resposta));
                   await userController.update(_email, _phone, _password);
                 },
               ),

--- a/lib/screens/adminConfig_screen.dart
+++ b/lib/screens/adminConfig_screen.dart
@@ -66,6 +66,8 @@ class AdminConfigState extends State<AdminConfig> {
                     _password = passwordCon.text;
                     _phone = phoneCon.text;
                   });
+                  userController.checkToken().then(
+                      (resposta) => MyWidgets().logout(context, resposta));
                   userController.delete();
                   Navigator.push(context,
                       MaterialPageRoute(builder: (context) => LoginMenu()));

--- a/lib/screens/adminConfig_screen.dart
+++ b/lib/screens/adminConfig_screen.dart
@@ -17,6 +17,22 @@ class AdminConfigState extends State<AdminConfig> {
   var _email;
   var _password;
 
+  void deleteUser(bool resposta) {
+    if (resposta) {
+      userController.delete();
+      Navigator.push(
+          context, MaterialPageRoute(builder: (context) => LoginMenu()));
+    } else
+      MyWidgets().logout(context, resposta);
+  }
+
+  void updateUser(bool resposta) async {
+    if (resposta) {
+      await userController.update(_email, _phone, _password);
+    } else
+      MyWidgets().logout(context, resposta);
+  }
+
   @override
   void initState() {
     super.initState();
@@ -65,11 +81,9 @@ class AdminConfigState extends State<AdminConfig> {
                     _password = passwordCon.text;
                     _phone = phoneCon.text;
                   });
-                  userController.checkToken().then(
-                      (resposta) => MyWidgets().logout(context, resposta));
-                  userController.delete();
-                  Navigator.push(context,
-                      MaterialPageRoute(builder: (context) => LoginMenu()));
+                  userController
+                      .checkToken()
+                      .then((resposta) => deleteUser(resposta));
                 },
                 child: Text(
                   "Excluir\nUsuário",
@@ -99,15 +113,15 @@ class AdminConfigState extends State<AdminConfig> {
                 50,
                 17,
                 Theme.of(context).primaryColor,
-                () async {
+                () {
                   setState(() {
                     _email = emailCon.text;
                     _phone = phoneCon.text;
                     _password = passwordCon.text;
                   });
-                  userController.checkToken().then(
-                      (resposta) => MyWidgets().logout(context, resposta));
-                  await userController.update(_email, _phone, _password);
+                  userController
+                      .checkToken()
+                      .then((resposta) => updateUser(resposta));
                 },
               ),
               Padding(

--- a/lib/services/api.dart
+++ b/lib/services/api.dart
@@ -110,22 +110,30 @@ abstract class ApiBase with Store {
     return response;
   }
 
-    @action
-  postTakenVaccine(String profileId, String vaccineId, String numberOfDosesTaken) async {
-    Response response = await dio.post('/taken',
-        data: {'profileId': profileId, 'vaccineId': vaccineId, 'numberOfDosesTaken': numberOfDosesTaken},
-      );
+  @action
+  postTakenVaccine(
+      String profileId, String vaccineId, String numberOfDosesTaken) async {
+    Response response = await dio.post(
+      '/taken',
+      data: {
+        'profileId': profileId,
+        'vaccineId': vaccineId,
+        'numberOfDosesTaken': numberOfDosesTaken
+      },
+    );
     return response;
   }
 
   @action
-  getTakenVaccines()async {
+  getTakenVaccines() async {
     var token = userController.token;
     var currentProfile = profileController.currentId;
-    Response response = await dio.get('/taken/p/$currentProfile',
-        options: Options(
-          headers: {'Authorization': 'Bearer $token'},
-        ));
+    Response response = await dio.get(
+      '/taken/p/$currentProfile',
+      // options: Options(
+      //   headers: {'Authorization': 'Bearer $token'},
+      // ),
+    );
     return response;
   }
 
@@ -136,7 +144,7 @@ abstract class ApiBase with Store {
   }
 
   @action
-  getVaccineById(String vacinaId) async{
+  getVaccineById(String vacinaId) async {
     print(vacinaId);
     Response response = await dio.get('/vaccine/$vacinaId');
     return response;

--- a/lib/services/api.dart
+++ b/lib/services/api.dart
@@ -145,7 +145,6 @@ abstract class ApiBase with Store {
 
   @action
   getVaccineById(String vacinaId) async {
-    print(vacinaId);
     Response response = await dio.get('/vaccine/$vacinaId');
     return response;
   }

--- a/lib/services/api.dart
+++ b/lib/services/api.dart
@@ -126,13 +126,13 @@ abstract class ApiBase with Store {
 
   @action
   getTakenVaccines() async {
-    //var token = userController.token;
+    var token = userController.token;
     var currentProfile = profileController.currentId;
     Response response = await dio.get(
       '/taken/p/$currentProfile',
-      // options: Options(
-      //   headers: {'Authorization': 'Bearer $token'},
-      // ),
+      options: Options(
+        headers: {'Authorization': 'Bearer $token'},
+      ),
     );
     return response;
   }

--- a/lib/services/api.dart
+++ b/lib/services/api.dart
@@ -126,7 +126,7 @@ abstract class ApiBase with Store {
 
   @action
   getTakenVaccines() async {
-    var token = userController.token;
+    //var token = userController.token;
     var currentProfile = profileController.currentId;
     Response response = await dio.get(
       '/taken/p/$currentProfile',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -190,13 +190,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
-  ffi:
-    dependency: transitive
-    description:
-      name: ffi
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.0"
   file:
     dependency: transitive
     description:
@@ -237,11 +230,6 @@ packages:
     version: "4.1.0"
   flutter_test:
     dependency: "direct dev"
-    description: flutter
-    source: sdk
-    version: "0.0.0"
-  flutter_web_plugins:
-    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -371,27 +359,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
-  path_provider_linux:
-    dependency: transitive
-    description:
-      name: path_provider_linux
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
-  path_provider_platform_interface:
-    dependency: transitive
-    description:
-      name: path_provider_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.1"
-  path_provider_windows:
-    dependency: transitive
-    description:
-      name: path_provider_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.1"
   pedantic:
     dependency: transitive
     description:
@@ -399,20 +366,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.11.0"
-  platform:
-    dependency: transitive
-    description:
-      name: platform
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.0.0"
-  plugin_platform_interface:
-    dependency: transitive
-    description:
-      name: plugin_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
   pool:
     dependency: transitive
     description:
@@ -420,13 +373,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.0"
-  process:
-    dependency: transitive
-    description:
-      name: process
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "4.2.1"
   pub_semver:
     dependency: transitive
     description:
@@ -441,48 +387,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
-  shared_preferences:
-    dependency: "direct main"
-    description:
-      name: shared_preferences
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.5"
-  shared_preferences_linux:
-    dependency: transitive
-    description:
-      name: shared_preferences_linux
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
-  shared_preferences_macos:
-    dependency: transitive
-    description:
-      name: shared_preferences_macos
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
-  shared_preferences_platform_interface:
-    dependency: transitive
-    description:
-      name: shared_preferences_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
-  shared_preferences_web:
-    dependency: transitive
-    description:
-      name: shared_preferences_web
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
-  shared_preferences_windows:
-    dependency: transitive
-    description:
-      name: shared_preferences_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
   shelf:
     dependency: transitive
     description:
@@ -656,20 +560,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
-  win32:
-    dependency: transitive
-    description:
-      name: win32
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.5"
-  xdg_directories:
-    dependency: transitive
-    description:
-      name: xdg_directories
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.2.0"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -190,6 +190,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   file:
     dependency: transitive
     description:
@@ -230,6 +237,11 @@ packages:
     version: "4.1.0"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -289,6 +301,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.1"
+  jwt_decoder:
+    dependency: "direct main"
+    description:
+      name: jwt_decoder
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   logging:
     dependency: transitive
     description:
@@ -352,6 +371,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   pedantic:
     dependency: transitive
     description:
@@ -359,6 +399,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.11.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   pool:
     dependency: transitive
     description:
@@ -366,6 +420,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.0"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.2.1"
   pub_semver:
     dependency: transitive
     description:
@@ -380,6 +441,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.5"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  shared_preferences_macos:
+    dependency: transitive
+    description:
+      name: shared_preferences_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   shelf:
     dependency: transitive
     description:
@@ -553,6 +656,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.5"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,6 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   jwt_decoder: ^2.0.1
-  shared_preferences: ^2.0.5
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,8 @@ dependencies:
   intl: ^0.17.0
   flutter_localizations:
     sdk: flutter
+  jwt_decoder: ^2.0.1
+  shared_preferences: ^2.0.5
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/test/profileController_test.dart
+++ b/test/profileController_test.dart
@@ -1,7 +1,7 @@
 import 'package:test/test.dart';
 import 'package:e_vacina/controllers/profileController.dart';
-void main() {
 
+void main() {
   group('ProfileController', () {
     test('currentId should start with null ', () {
       ProfileController profileController = new ProfileController();
@@ -39,6 +39,10 @@ void main() {
       expect(profileController.names, null);
     });
 
+    test('currentIndex should start with 0 ', () {
+      ProfileController profileController = new ProfileController();
 
+      expect(profileController.currentIndex, 0);
+    });
   });
 }


### PR DESCRIPTION
### Descrição - Mantem o login do usuário mesmo após o aplicativo ser fechado.
- FlutterSecureStorage() adicionados na UserController.dart e no componente ListProfiles.dart. (Comentar para rodar o aplicativo pelo Chrome).
- Adicionando função logout() em MyWidgets.dart, para ser usada sempre que for checada a validade do token.
- Adicionando uma variável currentIndex no ProfileController para tornar possível o login no mesmo perfil logado anteriormente.
- No UserController.dart, adicionados métodos para persistir login e para checar validade do token.
- Adicionando a chamada do método checkToken em todos os casos que o token for necessário.
- Mudando de navigateAfterSeconds para navigateAfterFuture na SplashScreen.dart, para que a tela mude apenas após persistir o login.
- Adicionando dependências no pubspec.yaml: jwt_decoder.
- Adicionando teste para a variável currentIndex do ProfilleController.dart.

### Porque este Pull Request é necessário?
Para o usuário continuar tendo acesso ao aplicativo mesmo após sair dele, impedindo a necessidade de um novo login.

### Critérios de Aceitação
#### Checklist

- [x] Testes passando.
- [x] Build passando.
- [x] Sem conflitos com a Branch Main ou Development.

Resolve #171.
